### PR TITLE
fix: Dependabotバージョンアップデートを無効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary
- `open-pull-requests-limit: 0` を追加
- セキュリティアップデートPRのみ有効、バージョンアップデートPRを無効化
- cooldown設定は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)