### PR TITLE
作業ブランチへの push で GitHub Pages が更新されてしまう問題を修正

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,5 +1,8 @@
 name: Build and Deploy
-on: [push]
+# 作業ブランチへの push で本番へ配信されないよう、対象を既定ブランチに限定する
+on:
+  push:
+    branches: ["main"]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 問題

`on: [push]` はブランチを限定していないため、**どのブランチに push しても本番への配信が走ります**。

実際に今回、Dependabot 設定を追加する PR（`chore/dependabot-tuning` ブランチ）を push しただけで、以下が実行されました。

- `.github/workflows/gh-pages.yaml` → GitHub Pages

PR をレビューしてもらう前の作業ブランチの内容が、そのまま本番に出てしまう状態です。今回は変更が `.github/dependabot.yml` の追加のみで配信物に影響しませんでしたが、コードを変更する PR だった場合はレビュー前の内容が公開されます。

## 変更内容

トリガーを既定ブランチ（`main`）に限定します。

```diff
-on: [push]
+# 作業ブランチへの push で本番へ配信されないよう、対象を既定ブランチに限定する
+on:
+  push:
+    branches: ["main"]
```

これにより、`main` へマージされたときだけ配信が走ります。

## 補足

同じ設定の残っているリポジトリが他に 8 件あり、それぞれ個別に PR を出しています。
また、ブランチは限定されているものの `paths` フィルタがなく、設定ファイルや README だけの変更でも本番配信が走るリポジトリが 19 件あります。そちらは別途ご相談させてください。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
