### PR TITLE
fix(ci): Actionsのセキュリティチェックの指摘を修正

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -3,6 +3,10 @@ name: Build and Deploy
 on:
   push:
     branches: ["main"]
+
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -12,6 +16,8 @@ jobs:
           node-version: 20
       - name: Checkout 🛎️
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install and Build 🔧
         run: |
           npm ci --ignore-scripts


### PR DESCRIPTION
## 概要

静的解析ツール [zizmor](https://github.com/zizmorcore/zizmor) を使って、CALIL Inc 内の全リポジトリの GitHub Actions ワークフローを点検しています。本リポジトリで検出された指摘を修正しました。

## 修正前後の findings 件数

`zizmor --min-severity low` の結果: **2件 → 0件**

## 修正内容

- ワークフローに `permissions: contents: write` を追加しました。
  **なぜ必要か**: このワークフローは `JamesIves/github-pages-deploy-action` を使って `gh-pages` ブランチへ push する方式でデプロイしているため、ブランチへの書き込み権限が必要です。permissions ブロックが無いと既定の広い権限が使われてしまうため、必要な `contents: write` のみに絞りました。
- checkout ステップに `persist-credentials: false` を追加しました。
  **なぜ必要か**: チェックアウト時に認証情報をローカルのgit設定に残さないようにする一般的なハードニングです。デプロイに使うトークンは `github-pages-deploy-action` 側が別途利用するため、この設定によるデプロイへの影響はありません。

## 保留にした指摘

なし（今回検出された2件はいずれも修正済みです。事前に共有された内訳表では「excessive-permissions 2件」となっていましたが、実際の zizmor 実行結果は excessive-permissions 1件 + artipacked(認証情報の永続化) 1件でした。両方とも対応済みです）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)