### PR TITLE
chore(ci): GitHub Pages の配信を公式 Action 方式へ移行（カスタムドメイン対応）

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,15 +1,33 @@
 name: Build and Deploy
+
+# GitHub Pages への配信。gh-pages ブランチを経由せず、公式 Action で
+# ビルド成果物を直接 Pages へ渡す。
+#
+# カスタムドメインについて:
+#   これまでは gh-pages ブランチ上の CNAME ファイルでドメインを保持していた。
+#   この方式では artifact の中に CNAME が入っている必要があるため、
+#   ソース側（ビルド時にそのままコピーされる場所）に CNAME を置いている。
+#
+# 前提: リポジトリ設定 Settings → Pages → Source が "GitHub Actions" であること。
 # 作業ブランチへの push で本番へ配信されないよう、対象を既定ブランチに限定する
 on:
   push:
     branches: ["main"]
 
-permissions:
-  contents: write
+permissions: {}
+
+# 配信が同時に走らないよう直列化する
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # configure-pages が Pages サイトの情報を取得するために必要
+      pages: read
     steps:
       - uses: actions/setup-node@v7
         with:
@@ -17,14 +35,35 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v7
         with:
+          # 配信は artifact 経由で行うため、checkout の資格情報は使わない
           persist-credentials: false
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
       - name: Install and Build 🔧
         run: |
           npm ci --ignore-scripts
           npm run build
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
+      - name: CNAME が成果物に含まれているか確認
+        run: test -f dist/CNAME
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          branch: gh-pages
-          folder: dist/
+          path: dist/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write      # Pages へ配信する
+      id-token: write   # 配信元を検証する OIDC トークンの発行
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/src/CNAME
+++ b/src/CNAME
@@ -1,0 +1,1 @@
+barcode.calil.dev


### PR DESCRIPTION
## 何をする PR か

GitHub Pages への配信を **gh-pages ブランチ経由から公式 Action 方式へ**移行します。このリポジトリは**カスタムドメイン `barcode.calil.dev` を使っている**ため、CNAME の扱いが加わります。

## カスタムドメインの扱い

これまではドメインを **gh-pages ブランチ上の `CNAME` ファイル**で保持していました。公式方式では gh-pages ブランチを使わなくなるため、**artifact の中に CNAME が入っている必要があります**。

そこで `src/CNAME` を追加しました。ビルド時にそのまま出力先へコピーされる場所なので、`dist/CNAME` として成果物に含まれます。

```
$ npm run build
$ cat dist/CNAME
barcode.calil.dev
```

**ローカルで実際にビルドして確認済み**です。加えて CI にも存在確認のステップを入れました。

```yaml
      - name: CNAME が成果物に含まれているか確認
        run: test -f dist/CNAME
```

取りこぼすとドメインが失われてサイトにアクセスできなくなるため、二重に守っています。

## ワークフローの変更

```diff
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@<SHA>
-        with:
-          branch: gh-pages
-          folder: dist/
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      ...
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: dist/
+
+  deploy:
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v5
```

ビルド手順は変えていません。

## なぜ

| 観点 | 現状 | 移行後 |
|---|---|---|
| 依存 | サードパーティ Action（個人アカウント提供） | **GitHub 公式のみ** |
| 必要な権限 | `contents: write` | `pages: read/write` + `id-token: write` |
| gh-pages ブランチ | 必要 | **不要** |

## 前例

org 内の **`bunrui-paper` が同じ構成（カスタムドメイン + 公式方式 + `public/CNAME`）で既に稼働**しています（`bunrui-paper.calil.dev` は HTTP 200）。その実装に倣いました。

Pages 方式の移行自体は9リポジトリで完了し、すべてデプロイ成功を確認しています。

## ⚠️ マージ後に設定変更が必要

**Settings → Pages → Source を `GitHub Actions` に変更**します。マージ時に私が API で切り替え、**https://barcode.calil.dev/ が引き続き見えるか**まで確認します。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
