### PR TITLE
GitHub Pages 配信から不要な configure-pages を外して構成を簡素化

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # configure-pages が Pages サイトの情報を取得するために必要
-      pages: read
     steps:
       - uses: actions/setup-node@v7
         with:
@@ -37,9 +35,6 @@ jobs:
         with:
           # 配信は artifact 経由で行うため、checkout の資格情報は使わない
           persist-credentials: false
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
 
       - name: Install and Build 🔧
         run: |


### PR DESCRIPTION
## このPRでやること

GitHub Pages の配信ワークフローから `actions/configure-pages` のステップを取り除きます。
（該当リポジトリでは、あわせて このステップのために付けていた `pages: read` 権限も外します）

## なぜ外せるのか

`actions/configure-pages` の仕事は次の2つだけです。

1. **静的サイトジェネレータの設定を自動で書き換える** — `static_site_generator: next` などを
   指定したときだけ動きます。指定がなければ何もしません。
2. **Pages サイトの情報を outputs として出す** — `base_path` / `base_url` / `origin` / `host` /
   `path` を後続のステップから参照できるようにします。

カーリルの Pages 配信ワークフローを全件調べたところ、

- `static_site_generator` を指定しているリポジトリは **1つもありません**
- outputs（`base_path` など）を参照しているリポジトリも **1つもありません**
  （base path はソース側の `vite.config.ts` などで指定済み）

つまりこのステップは**実行されるだけで何の効果もない**状態でした。
配信の実務は `actions/upload-pages-artifact`（成果物のアップロード）と
`actions/deploy-pages`（配信）が担っており、この2つがあれば動きます。

## 得られること

- ワークフローが1ステップ短くなり、読んだときの「これは何のためにあるのか」が減る
- `pages: read` 権限が不要になる（権限は少ないほうが安全）
- ステップ数が減るぶん、実行時間もわずかに短くなる

## 安全性の確認

このPRを出す前に、以下を機械的に検証しています。

- [x] 起動条件（`on:`）とジョブ構成は変更なし
- [x] 消えたステップは `configure-pages` の1つだけ（ステップ数が想定どおり1つだけ減っている）
- [x] `upload-pages-artifact` / `deploy-pages` は残っている
- [x] `deploy` ジョブはいっさい変更していない
- [x] リポジトリ設定の Pages ソースは **GitHub Actions**（このPR後も配信方式は変わらない）
- [x] Actions のセキュリティチェック（zizmor）で指摘 0 件

`configure-pages` には Pages のソースを「GitHub Actions」に切り替える `enablement` という
入力もありますが、既定値は `false` で、どのリポジトリでも指定していません。
また全リポジトリでソースは既に「GitHub Actions」になっているため、切り替え目的でも不要です。

## マージ後

`main`（または `master`）への push で配信ワークフローが走り、実際に配信されることを確認します。
