### PR TITLE
上げられない依存を Dependabot の対象から外す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # React 19 には上げられない。
+      # semantic-ui-react の peer が "^16.8.0 || ^17.0.0 || ^18.0.0" で 19 に
+      # 対応しておらず、本体も 2.1.5 から動きがない。peer の不一致は npm では
+      # 警告どまりでビルドも通ってしまうため、CI では気づけない。壊れるとしたら
+      # 実行時になる。上げるなら UI ライブラリの乗り換えとセットで判断する。
+      - dependency-name: "react"
+        versions: [">=19"]
+      - dependency-name: "react-dom"
+        versions: [">=19"]
+      - dependency-name: "@types/react"
+        versions: [">=19"]
+      - dependency-name: "@types/react-dom"
+        versions: [">=19"]
+      # @types/node は動かすランタイムに合わせる（.nvmrc = 24）。
+      # major が先に上がると、実際には無い API の型が通ってしまう。
+      # Node.js を上げるときは .nvmrc と一緒に手で上げる。
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # GitHub Actions (.github/workflows)


### PR DESCRIPTION
## 上げられない依存を Dependabot の対象から外す

CI が無かった間に溜まっていた Dependabot の PR に、**そのままマージすると問題が出るもの**が混じっていました。上がってこないよう `ignore` を追加します。

| 対象 | 理由 |
|---|---|
| `react` / `react-dom` / `@types/react` / `@types/react-dom` の **19 以降** | `semantic-ui-react` の peer が `^16.8.0 \|\| ^17.0.0 \|\| ^18.0.0` で React 19 に対応しておらず、本体も 2.1.5 から動きがありません |
| `@types/node` の **major** | 動かすランタイムに合わせるべきものです（`.nvmrc` = 24） |

React 19 が厄介なのは、**peer の不一致は npm では警告どまりでビルドも通ってしまう**点です。CI を足しても気づけず、壊れるとしたら実行時になります。上げるなら UI ライブラリの乗り換えとセットで判断することになります。

`@types/node` も、major が先に上がると実際には存在しない API の型が通ってしまいます。Node.js 側を上げるときに `.nvmrc` と一緒に手で上げる運用にします。

18 系・24 系の中での minor / patch はこれまでどおり流れてきます。

このPRのマージ後、対象の Dependabot PR（#45 / #46 / #48）を閉じます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
