### PR TITLE
chore(deps): 未使用の jsurl を外し、paper-css をパッケージ名で読む

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "detect-browser": "^5.3.0",
         "fomantic-ui-css": "^2.9.4",
         "jsbarcode": "^3.12.3",
-        "jsurl": "^0.1.5",
         "paper-css": "^0.4.1",
         "query-string": "^9.4.1",
         "react": "^18.3.1",
@@ -956,11 +955,6 @@
       "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.12.3.tgz",
       "integrity": "sha512-CuHU9hC6dPsHF5oVFMo8NW76uQVjH4L22CsP4hW+dNnGywJHC/B0ThA1CTDVLnxKLrrpYdicBLnd2xsgTfRnvg==",
       "license": "MIT"
-    },
-    "node_modules/jsurl": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/jsurl/-/jsurl-0.1.5.tgz",
-      "integrity": "sha512-HyrafsIRCa+VlJAsvuvxWUM0iMeZd6+2J4JngECGF0JTRi5moUFV/mLxgyYfDizGF4ofLLYRpvD/Kt1d9wlUUg=="
     },
     "node_modules/keyboard-key": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "detect-browser": "^5.3.0",
     "fomantic-ui-css": "^2.9.4",
     "jsbarcode": "^3.12.3",
-    "jsurl": "^0.1.5",
     "paper-css": "^0.4.1",
     "query-string": "^9.4.1",
     "react": "^18.3.1",

--- a/src/index.sass
+++ b/src/index.sass
@@ -1,4 +1,4 @@
-@import '../node_modules/paper-css/paper.min.css'
+@import 'paper-css/paper.min.css'
   
 @font-face
   font-family: 'Conv_OCRB'


### PR DESCRIPTION
## 何をしたか

1. **未使用の `jsurl` を依存から外した**
   knip + depcheck のクロスチェックで未使用と出たもの。リポジトリ全体を検索しても
   `package.json` / `package-lock.json` 以外に参照は無い。URL のクエリ組み立ては
   `query-string` が担っている（`src/App.tsx`）。

2. **`paper-css` の読み込みを node_modules 相対パスからパッケージ名に変えた**
   `@import '../node_modules/paper-css/paper.min.css'` → `@import 'paper-css/paper.min.css'`
   `index.tsx` が `import 'fomantic-ui-css/semantic.css'` と書いているのと同じ流儀に揃えた。
   `.css` で終わるので sass は plain CSS の `@import` として素通しし、実際の解決は Vite が行う。

## 確認したこと

- `npm ci && npm run build` が通る
- **成果物の CSS・JS が変更前と SHA256 まで一致する**（`index-oVwo4yYR.css` / `index-DLcc7pV1.js`）
- `vite dev` でも `paper-css` が展開される（`/src/index.sass` の応答に `.sheet` が34件、`@import` の残留は0件）

## 検討したが採らなかった案

`paper-css` の読み込みを `index.sass` から `index.tsx` へ移す案（`import 'paper-css/paper.min.css'`）も
試したが、成果物での `paper-css` の位置が `index.sass` の後ろへ回ってしまう。
`paper-css` には `@media screen { body { background: #e0e0e0 } }` があり、これが `index.sass` の
`body { background-color: #ffffff }` に勝つため、**画面表示の背景が白から灰色に変わる**。
カスケード順を保つため読み込みは `index.sass` の先頭に残した。

## 付随して気づいたこと（このPRでは直していない）

- `src/index.sass` 19・20行目の `@import './sass/App.sass'` / `@import './sass/Steps.sass'` は
  Dart Sass 3.0 で削除される非推奨の Sass `@import`。ビルド時に DEPRECATION WARNING が出ている。
  どちらの partial も変数・mixin を持たないただの規則集合なので `@use` への置き換えは容易。
  （1行目の `paper-css` は plain CSS の `@import` なので非推奨の対象ではない）
- `vite.config.ts` が CommonJS として読まれており、Vite の将来の既定 `configLoader: 'native'`
  では動かないという警告が出ている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
