### PR TITLE
refactor(style): 非推奨の Sass @import を @use へ置き換える

### DIFF
--- a/src/_base.sass
+++ b/src/_base.sass
@@ -1,0 +1,24 @@
+// index.sass にあった全体向けの定義。
+// @use は他の規則（plain CSS の @import も含む）より前に置く必要があるため、
+// index.sass を @use の一覧にし、中身をここへ移した。
+// 読み込み順は元の @import と同じ（これが最初）。
+//
+// 置き場が src/sass ではなく src/ なのは、下の url('./fonts/...') が
+// index.sass と同じ相対位置のままになるようにするため。
+
+@import 'paper-css/paper.min.css'
+
+@font-face
+  font-family: 'Conv_OCRB'
+  src: url('./fonts/OCRB.eot')
+  src: url('./fonts/OCRB.woff') format("woff"), url('./fonts/OCRB.ttf') format("truetype"), url('./fonts/OCRB.svg') format("svg")
+  font-weight: normal
+  font-style: normal
+
+body
+  margin: 0
+  padding: 0
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: grayscale
+  background-color: #ffffff

--- a/src/index.sass
+++ b/src/index.sass
@@ -1,20 +1,3 @@
-@import 'paper-css/paper.min.css'
-  
-@font-face
-  font-family: 'Conv_OCRB'
-  src: url('./fonts/OCRB.eot')
-  src: url('./fonts/OCRB.woff') format("woff"), url('./fonts/OCRB.ttf') format("truetype"), url('./fonts/OCRB.svg') format("svg")
-  font-weight: normal
-  font-style: normal
-  
-body
-  margin: 0
-  padding: 0
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif
-  -webkit-font-smoothing: antialiased
-  -moz-osx-font-smoothing: grayscale
-  background-color: #ffffff
-
-
-@import './sass/App.sass'
-@import './sass/Steps.sass'
+@use 'base'
+@use 'sass/App'
+@use 'sass/Steps'


### PR DESCRIPTION
## なぜ

Dart Sass は `@import` を非推奨にしており、**Dart Sass 3.0 で削除**される。
#58 の本文で「付随して気づいたこと」として挙げていた件で、org 横断の棚卸しの一部。

## どう直したか

`@use` は「他の規則より前」に置く必要がある。末尾の `@import` をそのまま `@use` に
すると、**モジュールの CSS が先頭に出て読み込み順（カスケード）が入れ替わる**。
そこで `index.sass` を `@use` の一覧にし、中身を `src/_base.sass` へ移した。

`paper-css` の読み込み（plain CSS の `@import`）も `_base.sass` の先頭へ移している。
plain CSS の `@import` は非推奨ではないが、これも「規則」なので `@use` より後ろに
置けない。位置は元と同じく最初なので出力順は変わらない。

`_base.sass` を `src/sass/` ではなく **`src/` に置いた**のは、`@font-face` の
`url('./fonts/...')` が `index.sass` と同じ相対位置のままになるようにするため。

## 確認したこと

- `npm run build` の成果物が移行前と一致（`index-oVwo4yYR.css` / `index-DLcc7pV1.js`、
  内容ハッシュ入りのファイル名も SHA256 も同じ）
- OCRB のフォント4種（eot / woff / ttf / svg）が同じサイズで出力されている
- DEPRECATION WARNING は **0件**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
