### PR TITLE
fix(deps): nanoid を 3.3.18 へ更新する (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 何を直すか

`nanoid` を 3.3.16 から **3.3.18** へ更新します。`package-lock.json` のみの変更で、`package.json` は触っていません。

## なぜ

| | |
|---|---|
| 脆弱性 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)（high・2026-07-29 公開） |
| 内容 | `size` に 0 を渡したときカスタムジェネレータが無限ループする |
| 影響 | `< 3.3.17` |
| 修正版 | `3.3.17`（2026-08-03 公開） |

`postcss` 経由の推移的依存です。postcss の要求レンジは `^3.3.x` なので、lockfile を更新するだけで解消し、メジャー更新も peer 依存の変更も発生しません。

## Dependabot では直らない

CALIL org の active な npm リポジトリ 64 件を横断確認したところ、**28 リポジトリ・30 マニフェスト**が 3.3.16 のまま残っていました。一方この advisory による Dependabot アラートは org 全体で 2 件しか発火しておらず（tankan / unilend）、残りは GitHub の dependency graph が `nanoid 3.3.16` を認識しているにもかかわらずアラートが立っていません。待っていても更新されないため、横断的に対応しています。

## 確認したこと

- diff が `package-lock.json` の `nanoid` エントリだけに閉じていること
- `lockfileVersion` が変わっていないこと
- JSON として妥当であること
- 更新後の lockfile に `nanoid < 3.3.17` が残っていないこと

`resolved` / `integrity` は npm registry の `nanoid@3.3.18` から取得した値です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
