### PR TITLE
chore: semantic-ui-react を廃止して React 19 へ更新する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,19 +39,18 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # React 19 には上げられない。
-      # semantic-ui-react の peer が "^16.8.0 || ^17.0.0 || ^18.0.0" で 19 に
-      # 対応しておらず、本体も 2.1.5 から動きがない。peer の不一致は npm では
-      # 警告どまりでビルドも通ってしまうため、CI では気づけない。壊れるとしたら
-      # 実行時になる。上げるなら UI ライブラリの乗り換えとセットで判断する。
+      # react のメジャー更新は周辺ライブラリの対応状況をまとめて確認してから
+      # 手動で判断する(2026-08 に semantic-ui-react が React 19 の findDOMNode
+      # 削除で実行時クラッシュし、本番が白画面になった経緯がある。同ライブラリは
+      # 廃止済みだが、major はマウントスモークテストと実ブラウザで検証してから上げる)。
       - dependency-name: "react"
-        versions: [">=19"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
-        versions: [">=19"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react"
-        versions: [">=19"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
-        versions: [">=19"]
+        update-types: ["version-update:semver-major"]
       # @types/node は動かすランタイムに合わせる（.nvmrc = 24）。
       # major が先に上がると、実際には無い API の型が通ってしまう。
       # Node.js を上げるときは .nvmrc と一緒に手で上げる。

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,13 @@
         "jsbarcode": "^3.12.3",
         "paper-css": "^0.4.1",
         "query-string": "^9.4.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "semantic-ui-react": "^2.1.5"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "@types/node": "^24.13.3",
-        "@types/react": "^18.3.31",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
         "jsdom": "^30.0.1",
         "sass": "^1.102.0",
@@ -61,15 +60,6 @@
       },
       "engines": {
         "node": "^22.13.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -276,36 +266,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@fluentui/react-component-event-listener": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
-      "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.4"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/@fluentui/react-component-ref": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
-      "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "react-is": "^16.6.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/@fluentui/react-component-ref/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -634,15 +594,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
@@ -904,19 +855,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@semantic-ui-react/event-stack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
-      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
-      "dependencies": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -970,32 +908,24 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1183,14 +1113,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1308,11 +1230,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -1415,11 +1332,6 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "node_modules/jsbarcode": {
       "version": "3.12.3",
       "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.12.3.tgz",
@@ -1466,11 +1378,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/keyboard-key": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -1733,29 +1640,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -1809,14 +1693,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/obug": {
       "version": "2.1.4",
@@ -1906,21 +1782,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1949,52 +1810,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
+        "react": "^19.2.8"
       }
     },
     "node_modules/readdirp": {
@@ -2090,42 +1923,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/semantic-ui-react": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.5.tgz",
-      "integrity": "sha512-nIqmmUNpFHfovEb+RI2w3E2/maZQutd8UIWyRjf1SLse+XF51hI559xbz/sLN3O6RpLjr/echLOOXwKCirPy3Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.5",
-        "@fluentui/react-component-event-listener": "~0.63.0",
-        "@fluentui/react-component-ref": "~0.63.0",
-        "@popperjs/core": "^2.6.0",
-        "@semantic-ui-react/event-stack": "^3.1.3",
-        "clsx": "^1.1.1",
-        "keyboard-key": "^1.1.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6 || ^17.0.0 || ^18.0.0",
-        "react-popper": "^2.3.0",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2501,14 +2302,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,13 @@
     "jsbarcode": "^3.12.3",
     "paper-css": "^0.4.1",
     "query-string": "^9.4.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "semantic-ui-react": "^2.1.5"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
-    "@types/react": "^18.3.31",
-    "@types/react-dom": "^18.3.7",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^30.0.1",
     "sass": "^1.102.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import {detect} from 'detect-browser'
 
 import Settings from './Settings'
 import Barcode from './Barcode'
-import {Button, Icon} from 'semantic-ui-react'
 
 import templates from './templates/index'
 
@@ -222,9 +221,9 @@ class App extends Component<Props, State> {
                     <header>
                         <h1>カーリルToolBox : バーコード連番印刷</h1>
                         <div style={{'position': 'absolute', 'top': '15px', 'right': '15px'}}>
-                            <Button as="a" href="https://github.com/CALIL/ajime" target="_blank" color="black">
-                                <Icon name='github'/> GitHub
-                            </Button>
+                            <a className="ui black button" href="https://github.com/CALIL/ajime" target="_blank">
+                                <i className="github icon" aria-hidden="true"/> GitHub
+                            </a>
                         </div>
                     </header>
                 )}

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react'
 
 import templates from './templates/index'
-import {Button, Form, Checkbox, Icon, Message, Input, Accordion, Divider, Label} from 'semantic-ui-react'
 
 interface Props {
     templateName: string
@@ -32,8 +31,7 @@ export default class Settings extends Component<Props, State> {
         }
     }
 
-    handleClick = (e: any, titleProps: any) => {
-        const {index} = titleProps
+    handleClick = (index: number) => {
         const {activeIndex} = this.state
         const newIndex = activeIndex === index ? -1 : index
         this.setState({activeIndex: newIndex})
@@ -58,62 +56,65 @@ export default class Settings extends Component<Props, State> {
             <div className="settings">
                 <div>
                     {this.props.supported === false ? (
-                        <Message negative size='small'>
+                        <div className="ui small negative message">
                             お使いのブラウザでは正しく印刷できない可能性があります。以下のブラウザを推奨します。
                             <ul>
-                                <li><a href="https://www.microsoft.com/ja-jp/edge" target="_blank">Microsoft Edge <Icon name='external'/></a></li>
-                                <li><a href="https://www.google.co.jp/chrome/index.html" target="_blank">Google Chrome <Icon name='external'/></a></li>
-                                <li><a href="https://www.mozilla.org/ja/firefox/" target="_blank">Firefox <Icon name='external'/></a></li>
+                                <li><a href="https://www.microsoft.com/ja-jp/edge" target="_blank">Microsoft Edge <i className="external icon" aria-hidden="true"/></a></li>
+                                <li><a href="https://www.google.co.jp/chrome/index.html" target="_blank">Google Chrome <i className="external icon" aria-hidden="true"/></a></li>
+                                <li><a href="https://www.mozilla.org/ja/firefox/" target="_blank">Firefox <i className="external icon" aria-hidden="true"/></a></li>
                             </ul>
-                        </Message>
+                        </div>
                     ) : null}
                     <div className="setting">
-                        <Accordion fluid>
-                            <Accordion.Title active={activeIndex === 0} index={0} onClick={this.handleClick}>
-                                <Icon name='dropdown'/>
+                        <div className="ui fluid accordion">
+                            <div className={activeIndex === 0 ? 'active title' : 'title'} onClick={() => this.handleClick(0)}>
+                                <i className="dropdown icon" aria-hidden="true"/>
                                 ラベル用紙を選ぶ
-                            </Accordion.Title>
-                            <Accordion.Content active={activeIndex === 0}>
-                                <Form>
-                                    <Form.Group grouped>
+                            </div>
+                            <div className={activeIndex === 0 ? 'active content' : 'content'}>
+                                <form className="ui form">
+                                    <div className="grouped fields">
                                         {Object.values(templates).map((template: any) => (
-                                            <Form.Field key={template.id}>
-                                                <Checkbox
-                                                    radio
-                                                    label={template.name}
-                                                    name='template'
-                                                    value={template.id}
-                                                    checked={template.id === this.props.templateName}
-                                                    onChange={(e, {value}) => this.props.onSelectTemplate(value as string)}
-                                                />
-                                            </Form.Field>
+                                            <div className="field" key={template.id}>
+                                                <div className="ui radio checkbox">
+                                                    <input
+                                                        type="radio"
+                                                        id={'template-' + template.id}
+                                                        name="template"
+                                                        value={template.id}
+                                                        checked={template.id === this.props.templateName}
+                                                        onChange={(e) => this.props.onSelectTemplate(e.target.value)}
+                                                    />
+                                                    <label htmlFor={'template-' + template.id}>{template.name}</label>
+                                                </div>
+                                            </div>
                                         ))}
-                                    </Form.Group>
-                                    <Message size='small'>
+                                    </div>
+                                    <div className="ui small message">
                                         <div>
                                             以下の用紙に対応しています。
                                             <ul>
                                                 {Object.values(templates).map((template: any) => {
                                                         if (template.id === this.props.templateName) {
                                                             return Object.values(template.sku).map((sku: any) => (
-                                                                <li key={sku[0]}><a href={sku[1]} target="_blank">{sku[0]} <Icon name='external'/></a></li>
+                                                                <li key={sku[0]}><a href={sku[1]} target="_blank">{sku[0]} <i className="external icon" aria-hidden="true"/></a></li>
                                                             ))
                                                         }
                                                     }
                                                 )}
                                             </ul>
                                         </div>
-                                    </Message>
-                                </Form>
-                            </Accordion.Content>
+                                    </div>
+                                </form>
+                            </div>
 
-                            <Accordion.Title active={activeIndex === 1} index={1} onClick={this.handleClick}>
-                                <Icon name='dropdown'/>
+                            <div className={activeIndex === 1 ? 'active title' : 'title'} onClick={() => this.handleClick(1)}>
+                                <i className="dropdown icon" aria-hidden="true"/>
                                 内容を決める
-                            </Accordion.Title>
-                            <Accordion.Content active={activeIndex === 1}>
-                                <Form>
-                                    <Message size='small'>
+                            </div>
+                            <div className={activeIndex === 1 ? 'active content' : 'content'}>
+                                <form className="ui form">
+                                    <div className="ui small message">
                                         <div>
                                             <ul style={{paddingLeft: '10px'}}>
                                                 <li>6桁～10桁程度が一般的です</li>
@@ -122,49 +123,58 @@ export default class Settings extends Component<Props, State> {
                                                 <li>エクセルなどで扱いやすくするたに「100000」などのようにゼロ埋めを不要とするのがおすすめです</li>
                                             </ul>
                                         </div>
-                                    </Message>
+                                    </div>
 
-                                    <Form.Field>
+                                    <div className="field">
                                         <label>開始番号</label>
-                                        <Input placeholder='000000...' className="startnum" value={this.props.startNumber} maxLength={14} required onChange={(e) => {
-                                            if (e.target.value.toUpperCase().match(/^[A-Z]*?[0-9]+C?$/)) {
-                                                this.props.changeStartNumber(e.target.value.toUpperCase())
-                                            } else {
-                                                e.target.value = this.props.startNumber
-                                            }
-                                        }}/>
-                                    </Form.Field>
-                                    <Form.Field>
+                                        <div className="ui input startnum">
+                                            <input placeholder='000000...' value={this.props.startNumber} maxLength={14} required onChange={(e) => {
+                                                if (e.target.value.toUpperCase().match(/^[A-Z]*?[0-9]+C?$/)) {
+                                                    this.props.changeStartNumber(e.target.value.toUpperCase())
+                                                } else {
+                                                    e.target.value = this.props.startNumber
+                                                }
+                                            }}/>
+                                        </div>
+                                    </div>
+                                    <div className="field">
                                         <label>図書館名</label>
-                                        <Input placeholder='カーリル図書館' value={this.props.libName} onChange={(e) => this.props.setLibName(e.target.value)}/>
+                                        <div className="ui input">
+                                            <input placeholder='カーリル図書館' value={this.props.libName} onChange={(e) => this.props.setLibName(e.target.value)}/>
+                                        </div>
                                         {(isWideHeight == false && this.props.libName.length > 0) ? (
-                                            <Label pointing>
+                                            <div className="ui pointing label">
                                                 ラベルが小さいため印刷されません
-                                            </Label>
+                                            </div>
                                         ) : null}
-                                    </Form.Field>
+                                    </div>
 
 
-                                </Form>
-                            </Accordion.Content>
+                                </form>
+                            </div>
 
-                            <Accordion.Title active={activeIndex === 2} index={2} onClick={this.handleClick}>
-                                <Icon name='dropdown'/>
+                            <div className={activeIndex === 2 ? 'active title' : 'title'} onClick={() => this.handleClick(2)}>
+                                <i className="dropdown icon" aria-hidden="true"/>
                                 枚数を決める
-                            </Accordion.Title>
-                            <Accordion.Content active={activeIndex === 2}>
-                                <Form>
-                                    <Form.Field>
+                            </div>
+                            <div className={activeIndex === 2 ? 'active content' : 'content'}>
+                                <form className="ui form">
+                                    <div className="field">
                                         <label>印刷するシートの枚数</label>
-                                        <Input className="countNumber" type="number" value={this.props.countNumber} min="1" max="300" required onChange={(e) => this.props.changeCountNumber(e.target.value)}/>
-                                    </Form.Field>
-                                </Form>
-                            </Accordion.Content>
-                        </Accordion>
-                        <Divider/>
+                                        <div className="ui input countNumber">
+                                            <input type="number" value={this.props.countNumber} min="1" max="300" required onChange={(e) => this.props.changeCountNumber(e.target.value)}/>
+                                        </div>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                        <div className="ui divider"/>
                         <div style={{'marginTop': '10px', 'textAlign': 'center'}}>
                             <p style={{"marginBottom": '10px'}}>合計 {parseInt(this.props.countNumber) * countPerPage} 個のバーコード</p>
-                            <Button primary icon loading={this.props.printing} size="big" labelPosition='right' onClick={this.props.print}>印刷する<Icon name='print'/></Button>
+                            <button
+                                className={'ui primary big icon right labeled button' + (this.props.printing ? ' loading' : '')}
+                                onClick={this.props.print}
+                            >印刷する<i className="print icon" aria-hidden="true"/></button>
                         </div>
                     </div>
                     <div className="cppyLink">
@@ -177,5 +187,4 @@ export default class Settings extends Component<Props, State> {
         )
     }
 }
-
 


### PR DESCRIPTION
## 概要

React 19 化の再挑戦です。前回(#60)の白画面の原因だった semantic-ui-react を廃止し、fomantic-ui-css のクラスを使った素の JSX に置き換えた上で React 19 へ更新します。tamalas-one の先例(doc/migration-vite-react19.md)に従った移行で、CALIL/resource-card にも同種の PR を出します。

## 背景

- semantic-ui-react 2.1.5 は内部の `@fluentui/react-component-ref` が `componentDidMount` で `ReactDOM.findDOMNode`(React 19 で削除)を呼ぶため、React 19 ではマウント時にクラッシュして白画面になります(#60 → #65 の経緯)
- 本体は 2023 年末から更新停止、React 19 対応版はありません
- #66 で導入したマウントスモークテストが今回の構成変更のゲートになっています(semantic-ui-react を残したまま React 19 に上げると CI が落ちることを実証済み)

## 変更内容

- `Settings.tsx`: 使用していた 9 コンポーネント(Accordion / Checkbox radio / Form / Input / Message / Label / Divider / Button / Icon)を fomantic-ui-css クラスの素の JSX へ。fomantic の CSS は `semantic.css` 全体 import 済みなので追加の CSS 変更は不要
  - radio は label クリックを効かせるため `id` + `htmlFor` で関連付け
  - Accordion は `active` クラスの付け外しで CSS が表示切替(jQuery 不要)。開閉アニメーションは無くなります(瞬時に開閉)
- `App.tsx`: GitHub ボタンを `<a className="ui black button">` に
- `package.json`: semantic-ui-react と peer 回避の overrides を削除、react / react-dom / @types を 19 系へ
- `dependabot.yml`: react の ignore を `versions: [">=19"]` 固定から semver-major 形式へ(19.x のマイナー更新まで止まっていたのを解消)

## 検証

- `npm run build` / `npm test`(jsdom マウント)パス
- 実ブラウザ(headless Chromium)で本番(React 18 + semantic-ui-react)と比較し同一挙動を確認:
  - テンプレート切替(ラジオ): SVG 44 → 36 → 44 / エーワン95面で 95
  - Accordion 3 セクションの開閉
  - 開始番号の入力(B00100C → CODE39 化)と不正入力の書き戻し
  - 図書館名入力時の pointing label(ラベル高 20mm 以下のテンプレートのみ表示、という既存挙動も一致)
  - スクリーンショット比較で見た目の変化なし
- バンドル: 330KB → 283KB(React 19 の +50KB を semantic-ui-react 削除が上回り -47KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)