### PR TITLE
chore: TypeScript 7 互換のために tsconfig を整理する

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,11 @@
     // vitest の型定義が vite のサブパス export を参照し moduleResolution: Node では
     // 解決できないため。自分のコード(src)の型チェックには影響しない
     "skipLibCheck": true,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## 概要

TypeScript 7 への更新（Dependabot #63）が tsconfig の廃止オプションでブロックされているため、TS7 互換の書き方へ先行整理します。**この変更は現行の TS 6 でも有効**で、この PR 単体で CI が通ります。

## 変更内容

- `esModuleInterop: false` を削除（TS7 では true 固定で false 指定は TS5108。`allowSyntheticDefaultImports: true` が既にあるため import 形式は互換）
- `moduleResolution: Node` → `bundler`（node10 は TS7 で削除。vite プロジェクトの推奨値）
- `src/vite-env.d.ts` を追加（TS7 では `fomantic-ui-css/semantic.css` や `./index.sass` の side-effect import が TS2882 になるため。vite テンプレート標準のファイル）

## 検証

- TS 6.0.3（現行）: `npm run build` パス
- TS 7.0.2: `npm run build` パス

マージ後、#63 を rebase して CI グリーンを確認してからマージします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERVipW4efqpQTjkKaqVoXr