### PR TITLE
refactor: detect-browser のブラウザ名判定を印刷機能の検出に置き換える

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "detect-browser": "^5.3.0",
         "fomantic-ui-css": "^2.9.4",
         "jsbarcode": "^3.12.3",
         "paper-css": "^0.4.1",
@@ -1524,11 +1523,6 @@
       "engines": {
         "node": ">=14.16"
       }
-    },
-    "node_modules/detect-browser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "detect-browser": "^5.3.0",
     "fomantic-ui-css": "^2.9.4",
     "jsbarcode": "^3.12.3",
     "paper-css": "^0.4.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import React, {Component} from 'react'
 
 import queryString from 'query-string'
-import {detect} from 'detect-browser'
 
 import Settings from './Settings'
 import Barcode from './Barcode'
+import {canPrint} from './printSupport'
 
 import templates from './templates/index'
+
+// 印刷に必要な機能がそろっているか。実行中に変わらないので一度だけ判定する。
+const printSupported = canPrint()
 
 // モジュラス10 ウェイト2・1分割(Luhn formula)（M10W21）
 // 1.数値の各桁に、下の桁から２・１・２・１・…の順番に係数（ウェイト）を掛けます。
@@ -75,7 +78,6 @@ interface State {
     prefixAlphabet: string // 先頭のアルファベット（存在する場合はCODE39になる）
     prefixZero: boolean // 先頭のゼロ埋めをするかどうか
     printing: boolean // 印刷中かどうか
-    supported: boolean // サポートブラウザかどうか
     noHeader: boolean // ヘッダーを表示しない
 }
 
@@ -83,9 +85,6 @@ class App extends Component<Props, State> {
     constructor(props: Props) {
         super(props)
         const ls = JSON.parse(localStorage.getItem('state') as string)
-        const browser = detect()
-        let supported = false
-        if (browser && (browser.name === 'chrome' || browser.name === 'firefox' || browser.name === 'edge' || browser.name === 'edge-chromium')) supported = true
         this.state = {
             templateName: ls && ls.templateName ? ls.templateName : 'aone-28368',
             libName: ls && ls.libName ? ls.libName : '',
@@ -97,7 +96,6 @@ class App extends Component<Props, State> {
             suffixCheckDigit: false,
             prefixAlphabet: '',
             printing: false,
-            supported: supported,
             noHeader: false
         }
     }
@@ -241,7 +239,7 @@ class App extends Component<Props, State> {
                         printing={this.state.printing}
                         print={this.print.bind(this)}
                         copyUrl={this.copyUrl.bind(this)}
-                        supported={this.state.supported}
+                        printSupported={printSupported}
                     />
                     <div className="sheets">
                         {this.state.splitNumbers.map((numbers, index) => {

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -15,7 +15,7 @@ interface Props {
     printing: boolean
     print: () => void
     copyUrl: () => void
-    supported: boolean
+    printSupported: boolean // 印刷に必要な機能がそろっているか
 }
 
 interface State {
@@ -55,7 +55,7 @@ export default class Settings extends Component<Props, State> {
         return (
             <div className="settings">
                 <div>
-                    {this.props.supported === false ? (
+                    {this.props.printSupported === false ? (
                         <div className="ui small negative message">
                             お使いのブラウザでは正しく印刷できない可能性があります。以下のブラウザを推奨します。
                             <ul>

--- a/src/printSupport.test.ts
+++ b/src/printSupport.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+//
+// 判定がブラウザ名ではなく機能の有無で行われていることを確かめる。
+// 許可リスト方式(detect-browser のブラウザ名判定)に戻る変更が入れば、
+// 「Safari の UA でも印刷 API があれば true」が落ちる。
+import {expect, test} from 'vitest'
+
+import {canPrint} from './printSupport'
+
+// window のうち canPrint が見る部分だけを持つ偽オブジェクト。
+// キーを渡さなければ「その機能が無いブラウザ」になる。
+const fakeWindow = (props: {print?: unknown; onafterprint?: unknown; navigator?: unknown}): Window =>
+    props as unknown as Window
+
+const SAFARI_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15'
+
+test('印刷に必要な機能がそろっていれば true', () => {
+    expect(canPrint(fakeWindow({print: () => {}, onafterprint: null}))).toBe(true)
+})
+
+test('window.print が無ければ false', () => {
+    expect(canPrint(fakeWindow({onafterprint: null}))).toBe(false)
+})
+
+test('afterprint に対応していなければ false', () => {
+    expect(canPrint(fakeWindow({print: () => {}}))).toBe(false)
+})
+
+test('Safari の UA でも印刷 API があれば true', () => {
+    const win = fakeWindow({
+        print: () => {},
+        onafterprint: null,
+        navigator: {userAgent: SAFARI_UA},
+    })
+    expect(canPrint(win)).toBe(true)
+})
+
+test('引数を省略すると実行中の window を見る', () => {
+    expect(canPrint()).toBe(true)
+})

--- a/src/printSupport.ts
+++ b/src/printSupport.ts
@@ -1,0 +1,44 @@
+// 印刷できる環境かどうかを、ブラウザ名ではなく機能の有無で判定する。
+//
+// もともとは detect-browser でブラウザ名の許可リストを見ていた。2021-08-02 に
+// 「safari を除外する」という否定形の判定を許可リストへ書き換えたもので(d83cd5ed)、
+// その直後に edge-chromium を後追いで足している(dcd8f73f)。新しいブラウザが出るたびに
+// 追記が必要な形になっていた。detect-browser 自体も 5.3.0 で更新が止まっている。
+//
+// この判定が分けているのは Settings.tsx の「正しく印刷できない可能性があります」という
+// 注意書きを出すかどうかだけで、印刷ボタン自体は塞いでいない。
+//
+// 許可リストが実際にはどの機能の有無を表していたのかを 2026-08-14 に実測した。
+// Chromium 151 / Firefox 153 / WebKit 26.5 (Safari 26.5 相当) で調べた結果、
+// 印刷に関わる機能はすべて一致していた。
+//
+//   window.print / onbeforeprint / onafterprint      … 3エンジンとも有り
+//   @page の margin と size, print-color-adjust        … 3エンジンとも解釈する
+//   mm 指定、grid + mm のレイアウト                     … 3エンジンとも同値
+//
+// さらにビルドした本体を print メディアで描画させてラベル位置を測ったところ、WebKit の
+// 結果は Chromium と完全に一致した(A4 シート 793.69 x 1118.73px、ラベル 182.55 x 96px、
+// 44個、1ページ)。つまり許可リストは「無い機能」を表しておらず、2021年当時の印刷結果の
+// 質の差をブラウザ名で覚えていただけだった。
+//
+// 用紙サイズ・倍率・余白といった印刷ダイアログ側の設定は JS から読めないので、
+// 実寸で出るかどうかを機能検出で代替することはできない。そこで、このアプリが印刷のために
+// 実際に使っている機能だけを直接見る形にした。どちらも欠ければ印刷は成り立たないので、
+// 注意書きを出す根拠になる。
+
+/** 「印刷する」ボタンが呼ぶ window.print() が使えるか(App.tsx の print())。 */
+const canOpenPrintDialog = (win: Window): boolean => typeof win.print === 'function'
+
+/**
+ * afterprint が飛んでくるか(App.tsx の componentDidMount で購読している)。
+ * 無いと印刷後に printing が false に戻らず、ボタンが読み込み中のまま止まり、
+ * 6枚目以降のシートも描画されたままになる。
+ */
+const hasPrintLifecycleEvent = (win: Window): boolean => 'onafterprint' in win
+
+/**
+ * 印刷に必要な機能がそろっているか。
+ * 実行中に変化しないので、呼び出し側で一度だけ判定すればよい。
+ */
+export const canPrint = (win: Window = window): boolean =>
+    canOpenPrintDialog(win) && hasPrintLifecycleEvent(win)


### PR DESCRIPTION
## やったこと

`detect-browser` でブラウザ名の許可リスト（`chrome` / `firefox` / `edge` / `edge-chromium`）を見ていた判定を、印刷に必要な機能の有無を直接見る形に置き換えました。新しいブラウザが出てもリストの保守が要らなくなります。

Todoist: 「ajime: detect-browser の UA 判定を機能検出に置き換える」

## 何を判定していたのか

`supported` が分けていたのは Settings の注意書き（「お使いのブラウザでは正しく印刷できない可能性があります」）を出すかどうかだけで、印刷ボタン自体は塞いでいません。

経緯をたどると、2021-08-02 の d83cd5ed で「safari を除外する」という否定形の判定を許可リストへ書き換えたもので、その直後 dcd8f73f で `edge-chromium` を後追いで足しています。保守が必要な形になっていたわけです。

## 許可リストは機能の差を表していなかった

Chromium 151 / Firefox 153 / WebKit 26.5（Safari 26.5 相当）で印刷まわりを実測しました。

| 調べたもの | 結果 |
|---|---|
| `window.print` / `onbeforeprint` / `onafterprint` | 3エンジンとも有り |
| `@page` の `margin` と `size`、`print-color-adjust` | 3エンジンとも解釈する |
| `mm` 指定、grid + `mm` のレイアウト | 3エンジンとも同値 |

さらにビルドした本体を print メディアで描画させてラベル位置を測ったところ、WebKit の結果は Chromium と完全に一致しました（A4 シート 793.69 x 1118.73px、ラベル 182.55 x 96px、44個、1ページ）。

つまり許可リストは「無い機能」を表しておらず、2021年当時の印刷結果の質の差をブラウザ名で覚えていただけでした。

## 何を見ることにしたか

用紙サイズ・倍率・余白といった印刷ダイアログ側の設定は JS から読めないので、実寸で出るかどうかを機能検出で代替することはできません。そのため、このアプリが印刷のために実際に使っている2つだけを見ています。

- `window.print()` … 「印刷する」ボタンが呼ぶ
- `afterprint` … 印刷後に `printing` 状態を戻すために購読している（`componentDidMount`）

どちらも欠ければ印刷は成り立たないので、注意書きを出す根拠になります。

## 変更点

- `src/printSupport.ts` を追加。判定の根拠と実測結果をコメントに残しました
- `State` の `supported` を廃止。実行中に変化しないので state ではなく定数にしました
- Settings の prop を `supported` から `printSupported` へ改名
- 許可リスト方式に戻る変更を捕まえる単体テストを追加（`src/printSupport.test.ts`）
- `detect-browser` を依存から外しました。npm 上も 5.3.0 で 2022年から更新が止まっています。`package-lock.json` は npm 経由だと他プラットフォーム向けの optional 依存を落とすことがあるため、手で該当ブロックだけ削除しています（差分は6行だけです）
- バンドルは 282.52 kB → 278.29 kB（-4.23 kB）

## 確認したこと

- `npm run build`（tsc + vite）とグリーンの `npm test`（6件・2ファイル）
- 3エンジンで、素の状態では注意書きが出ず、`window.print` か `onafterprint` のどちらかを取り上げると出ること
- 3エンジンで、変更前後でラベルのレイアウトが変わっていないこと（screen / print 両方）

## レビューしていただきたい点

**現代の Safari では注意書きが出なくなります。** ブラウザ名ではなく機能で判定した結果なので意図した変更ですが、利用者への影響があるのでご確認ください。

ユーザーに見える文言は変えていません。「正しく印刷できない可能性があります」という表現は印刷 API が無い場合にも当てはまるためそのままにしましたが、実寸ズレの本当のリスク（用紙 A4・余白なし・倍率100% という印刷ダイアログの設定）はブラウザ非依存で、機能検出では扱えません。これを常時の注意書きとして出すかどうかは UI の方針として別に決める話だと思うので、この PR には含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SecR8hdLdUCNr4dCXsweAk
